### PR TITLE
refactor: split legacy credentials support into separate component

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -1,9 +1,11 @@
 config:
   bjerk-core-infra:billingAccount:
     secure: AAABAEU/AT0YecFWCtiZTs5/idAfjuuY4dGFeS+l3onG8KZ3RBJcpO1bWpABu9mZrorP4w==
+  bjerk-core-infra:developers:
+    - group:developers@bjerk.io
   branches:developers:
-  - so@bjerk.io
-  - brage@bjerk.io
+    - so@bjerk.io
+    - brage@bjerk.io
   intg-avfnor:slack-channel: C03KE9E4QEQ
   slack-tripletex-agent:slack-channel: C03FB4MH45U
   slack:bot-oauth-token:

--- a/src/components/gcp-credentials-interface.ts
+++ b/src/components/gcp-credentials-interface.ts
@@ -1,0 +1,21 @@
+import * as pulumi from '@pulumi/pulumi';
+import * as gcp from '@pulumi/gcp';
+import * as github from '@pulumi/github';
+
+export interface GCPCredentialsArgs {
+  repositories: pulumi.Input<string>[];
+  projectId: pulumi.Input<string>;
+  serviceAccount: gcp.serviceaccount.Account;
+  owners?: pulumi.Input<string>[];
+
+  /**
+   * @default 'roles/owner'
+   *
+   * Use false to disable
+   */
+  serviceAccountRole?: string | false;
+}
+
+export interface GCPCredentials {
+  readonly secrets: pulumi.Output<github.ActionsSecret[]>;
+}

--- a/src/components/github-gcp-sa-key-credentials.ts
+++ b/src/components/github-gcp-sa-key-credentials.ts
@@ -1,0 +1,102 @@
+import * as pulumi from '@pulumi/pulumi';
+import * as gcp from '@pulumi/gcp';
+import * as github from '@pulumi/github';
+import {
+  GCPCredentials,
+  GCPCredentialsArgs,
+} from './gcp-credentials-interface';
+
+export class GitHubGCPServiceAccountKeyCredentials
+  extends pulumi.ComponentResource
+  implements GCPCredentials {
+  readonly serviceAccountKey: gcp.serviceaccount.Key;
+
+  readonly secrets: pulumi.Output<github.ActionsSecret[]>;
+  readonly serviceAccountRole: gcp.projects.IAMMember;
+
+  constructor(
+    name: string,
+    args: GCPCredentialsArgs,
+    opts?: pulumi.ComponentResourceOptions,
+  ) {
+    super('bjerk:github-gcp-service-account-credentials', name, args, opts);
+    const {
+      repositories,
+      projectId,
+      serviceAccount,
+      serviceAccountRole = 'roles/owner',
+    } = args;
+
+    this.serviceAccountKey = new gcp.serviceaccount.Key(
+      name,
+      {
+        serviceAccountId: serviceAccount.accountId,
+      },
+      {
+        parent: this,
+        aliases: [
+          {
+            name,
+            parent: `urn:pulumi:prod::bjerk-core-infra::bjerk:project::${name}`,
+          },
+        ],
+      },
+    );
+
+    if (serviceAccountRole) {
+      this.serviceAccountRole = new gcp.projects.IAMMember(
+        `${name}-service-account`,
+        {
+          member: pulumi.interpolate`serviceAccount:${serviceAccount.email}`,
+          role: serviceAccountRole,
+        },
+        { parent: this },
+      );
+    }
+
+    this.secrets = pulumi.output([
+      // GCP Project access
+      ...repositories.map(
+        (repository) =>
+          new github.ActionsSecret(
+            `${repository}-${name}-gcp-key`,
+            {
+              secretName: 'GOOGLE_PROJECT_SA_KEY',
+              plaintextValue: this.serviceAccountKey.privateKey,
+              repository,
+            },
+            {
+              parent: this,
+              aliases: [
+                {
+                  name: `${repository}-${name}-gcp-key`,
+                  parent: `urn:pulumi:prod::bjerk-core-infra::bjerk:project::${name}`,
+                },
+              ],
+            },
+          ),
+      ),
+      // Google project ID
+      ...repositories.map(
+        (repository) =>
+          new github.ActionsSecret(
+            `${repository}-${name}-gcp-project`,
+            {
+              secretName: 'GOOGLE_PROJECT_ID',
+              plaintextValue: projectId,
+              repository,
+            },
+            {
+              parent: this,
+              aliases: [
+                {
+                  name: `${repository}-${name}-gcp-project`,
+                  parent: `urn:pulumi:prod::bjerk-core-infra::bjerk:project::${name}`,
+                },
+              ],
+            },
+          ),
+      ),
+    ]);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,3 +10,5 @@ export const coreProject = 'bjerk-core';
 
 const branchesConfig = new pulumi.Config('branches');
 export const branchesDevelopers = branchesConfig.requireObject<string[]>('developers');
+
+export const developers = config.requireObject<string[]>('developers');

--- a/src/customers/bassene-web.ts
+++ b/src/customers/bassene-web.ts
@@ -1,5 +1,3 @@
-import * as pulumi from '@pulumi/pulumi';
-import * as gcp from '@pulumi/gcp';
 import { ProjectOnGithub } from '../components/projects-on-github';
 import { folder } from './folder';
 import { basssene } from '../github-orgs';
@@ -14,11 +12,3 @@ export const setup = new ProjectOnGithub(
   { providers: [basssene] },
 );
 
-export const dnsRole = new gcp.projects.IAMMember(
-  'bassene-web-dns-iam',
-  {
-    member: pulumi.interpolate`serviceAccount:${setup.serviceAccount.email}`,
-    role: 'roles/owner',
-  },
-  { provider: setup.googleProvider },
-);

--- a/src/customers/flexisoft.ts
+++ b/src/customers/flexisoft.ts
@@ -3,6 +3,7 @@ import * as gcp from '@pulumi/gcp';
 import { ProjectOnGithub } from '../components/projects-on-github';
 import { folder } from './folder';
 import { basssene, flexiSoft } from '../github-orgs';
+import { developers } from '../config';
 
 export const setup = new ProjectOnGithub(
   'flexisoft',
@@ -10,15 +11,8 @@ export const setup = new ProjectOnGithub(
     projectName: 'flexisoft-portal',
     folderId: folder.id,
     repository: 'conf',
+    // TODO: Restrict access
+    owners: developers,
   },
   { providers: [flexiSoft] },
-);
-
-export const dnsRole = new gcp.projects.IAMMember(
-  'flexisoft-dns-iam',
-  {
-    member: pulumi.interpolate`serviceAccount:${setup.serviceAccount.email}`,
-    role: 'roles/owner',
-  },
-  { provider: setup.googleProvider },
 );

--- a/src/customers/folder.ts
+++ b/src/customers/folder.ts
@@ -1,7 +1,16 @@
 import * as gcp from '@pulumi/gcp';
-import { organizationNumber } from '../config';
+import { developers, organizationNumber } from '../config';
 
 export const folder = new gcp.organizations.Folder('customer-folder', {
   displayName: 'Customers',
   parent: `organizations/${organizationNumber}`,
 });
+
+export const viewerUsers = developers.map(
+  (member) =>
+    new gcp.folder.IAMMember(`${member}-developer-viewer`, {
+      folder: folder.name,
+      role: 'roles/viewer',
+      member,
+    }),
+);

--- a/src/internal/bjerk-gaming.ts
+++ b/src/internal/bjerk-gaming.ts
@@ -2,7 +2,6 @@ import * as gcp from '@pulumi/gcp';
 import { ProjectOnGithub } from '../components/projects-on-github';
 import { folder } from './folder';
 import { bjerkio } from '../github-orgs';
-import { interpolate } from '@pulumi/pulumi';
 
 export const setup = new ProjectOnGithub(
   'bjerk-gaming',
@@ -13,12 +12,6 @@ export const setup = new ProjectOnGithub(
   },
   { providers: [bjerkio] },
 );
-
-export const ownerRole = new gcp.projects.IAMMember('bjerk-gaming-iam-cobraz', {
-  member: interpolate`user:so@bjerk.io`,
-  role: 'roles/owner',
-  project: 'bjerk-gaming',
-});
 
 export const services = [
   'servicemanagement.googleapis.com',

--- a/src/internal/bjerk-io.ts
+++ b/src/internal/bjerk-io.ts
@@ -16,12 +16,3 @@ export const setup = new ProjectOnGithub(
   },
   { providers: [bjerkio] },
 );
-
-export const dnsRole = new gcp.projects.IAMMember(
-  'bjerk-io-owner-iam',
-  {
-    member: pulumi.interpolate`serviceAccount:${setup.serviceAccount.email}`,
-    role: 'roles/owner',
-  },
-  { provider: setup.googleProvider },
-);

--- a/src/internal/btools.ts
+++ b/src/internal/btools.ts
@@ -30,22 +30,12 @@ export const setup = new ProjectOnGithub(
   { providers: [githubProvider] },
 );
 
-export const ownerRole = new gcp.projects.IAMMember(
-  'btools-owner-iam',
-  {
-    member: pulumi.interpolate`serviceAccount:${setup.serviceAccount.email}`,
-    role: 'roles/owner',
-  },
-  { provider: setup.googleProvider },
-);
-
 export const googleProvider = new gcp.Provider(
   'btools-google-provider',
   {
     project: project.name,
   }
 );
-
 
 export const services = [
   'servicemanagement.googleapis.com',

--- a/src/internal/slack-tripletex-agent.ts
+++ b/src/internal/slack-tripletex-agent.ts
@@ -1,4 +1,3 @@
-import * as pulumi from '@pulumi/pulumi';
 import * as gcp from '@pulumi/gcp';
 import { ProjectOnGithub } from '../components/projects-on-github';
 import { folder } from './folder';
@@ -18,15 +17,6 @@ export const setup = new ProjectOnGithub(
     repositories: ['slack-tripletex-agent'],
   },
   { providers: [bjerkio] },
-);
-
-export const dnsRole = new gcp.projects.IAMMember(
-  `${name}-owner-iam`,
-  {
-    member: pulumi.interpolate`serviceAccount:${setup.serviceAccount.email}`,
-    role: 'roles/owner',
-  },
-  { provider: setup.googleProvider },
 );
 
 export const services = [

--- a/src/internal/timely-agent.ts
+++ b/src/internal/timely-agent.ts
@@ -18,15 +18,6 @@ export const setup = new ProjectOnGithub(
   { providers: [bjerkio] },
 );
 
-export const dnsRole = new gcp.projects.IAMMember(
-  'timely-agent-owner-iam',
-  {
-    member: pulumi.interpolate`serviceAccount:${setup.serviceAccount.email}`,
-    role: 'roles/owner',
-  },
-  { provider: setup.googleProvider },
-);
-
 new ProjectSlackLogger(
   'timely-agent',
   { channel: config.require('slack-channel') },

--- a/src/internal/tripletex-time-agent.ts
+++ b/src/internal/tripletex-time-agent.ts
@@ -54,15 +54,6 @@ export const apiServices = services.map(
     ),
 );
 
-export const dnsRole = new gcp.projects.IAMMember(
-  'tripletex-time-agent-owner-iam',
-  {
-    member: pulumi.interpolate`serviceAccount:${setup.serviceAccount.email}`,
-    role: 'roles/owner',
-  },
-  { provider: setup.googleProvider },
-);
-
 new ProjectSlackLogger(
   'tripletex-time-agent',
   { channel: config.require('slack-channel') },


### PR DESCRIPTION
Moves legacy credentails out, so to make room for a modern authentication when needed.
